### PR TITLE
Fix disconnections 

### DIFF
--- a/bidfx/pricing/_pixie/pixie_provider.py
+++ b/bidfx/pricing/_pixie/pixie_provider.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 from datetime import datetime
+import traceback
 
 from bidfx._bidfx_api import BIDFX_API_INFO
 from bidfx.exceptions import PricingError, IncompatibleVersionError
@@ -107,7 +108,7 @@ class PixieProvider(PriceProvider):
             self._publish_provider_status(ProviderStatus.READY)
             self._price_server_read_loop()
         except Exception as e:
-            log.warning(f"connection attempt failed due to: {e}")
+            log.warning(f"connection attempt failed due to: {traceback.format_exc()}")
 
     def _prepare_new_session(self):
         self._decompressor = Decompressor()
@@ -143,7 +144,7 @@ class PixieProvider(PriceProvider):
                 del buffer
         except Exception as e:
             self._publish_provider_status(
-                ProviderStatus.DOWN, f"connection error due to: {e}"
+                ProviderStatus.DOWN, f"connection error due to: {traceback.format_exc()}"
             )
             self._notify_all_subjects_as_stale(
                 f"price provider {self._provider_name} is down"

--- a/bidfx/pricing/_pixie/pixie_provider.py
+++ b/bidfx/pricing/_pixie/pixie_provider.py
@@ -5,7 +5,6 @@ import os
 import threading
 import time
 from datetime import datetime
-import traceback
 
 from bidfx._bidfx_api import BIDFX_API_INFO
 from bidfx.exceptions import PricingError, IncompatibleVersionError
@@ -108,7 +107,7 @@ class PixieProvider(PriceProvider):
             self._publish_provider_status(ProviderStatus.READY)
             self._price_server_read_loop()
         except Exception as e:
-            log.warning(f"connection attempt failed due to: {traceback.format_exc()}")
+            log.warning(f"connection attempt failed due to: {e}")
 
     def _prepare_new_session(self):
         self._decompressor = Decompressor()
@@ -144,7 +143,7 @@ class PixieProvider(PriceProvider):
                 del buffer
         except Exception as e:
             self._publish_provider_status(
-                ProviderStatus.DOWN, f"connection error due to: {traceback.format_exc()}"
+                ProviderStatus.DOWN, f"connection error due to: {e}"
             )
             self._notify_all_subjects_as_stale(
                 f"price provider {self._provider_name} is down"

--- a/bidfx/pricing/_pixie/util/varint.py
+++ b/bidfx/pricing/_pixie/util/varint.py
@@ -96,7 +96,12 @@ def decode_varint_from_socket(socket_connection):
 
 
 def read_bytes(socket_connection, length):
-    byte_ = socket_connection.recv(length)
-    if byte_ == b"":
-        raise socket.error("end of socket stream")
-    return byte_
+    result = b""
+
+    while len(result) != length:
+        byte_ = socket_connection.recv(length - len(result))
+        if byte_ == b"":
+            raise socket.error("end of socket stream")
+        result += byte_
+        
+    return result

--- a/bidfx/pricing/_puffin/puffin_provider.py
+++ b/bidfx/pricing/_puffin/puffin_provider.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import time
 from base64 import b64decode, b64encode
+import traceback
 
 from Cryptodome.Cipher import PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
@@ -139,7 +140,7 @@ class PuffinProvider(PriceProvider):
             self._publish_provider_status(ProviderStatus.READY)
             self._price_server_read_loop()
         except Exception as e:
-            log.warning(f"connection attempt failed due to: {e}")
+            log.warning(f"connection attempt failed due to: {traceback.format_exc()}")
 
     def _prepare_new_session(self):
         self._compressor = MessageCompressor(self._opened_socket)
@@ -175,7 +176,7 @@ class PuffinProvider(PriceProvider):
                 self._handle_received_message(message)
         except Exception as e:
             self._publish_provider_status(
-                ProviderStatus.DOWN, f"connection error due to: {e}"
+                ProviderStatus.DOWN, f"connection error due to: {traceback.format_exc()}"
             )
             self._notify_all_subjects_as_stale(
                 f"price provider {self._provider_name} is down"
@@ -248,7 +249,7 @@ class PuffinProvider(PriceProvider):
             cipher = PKCS1_v1_5.new(key)
             return b64encode(cipher.encrypt(password.encode("utf-8")))
         except Exception as e:
-            print(e)
+            log.error(traceback.format_exc())
 
     @staticmethod
     def _verify_version(server_version):

--- a/bidfx/pricing/_puffin/puffin_provider.py
+++ b/bidfx/pricing/_puffin/puffin_provider.py
@@ -6,7 +6,6 @@ import socket
 import threading
 import time
 from base64 import b64decode, b64encode
-import traceback
 
 from Cryptodome.Cipher import PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
@@ -140,7 +139,7 @@ class PuffinProvider(PriceProvider):
             self._publish_provider_status(ProviderStatus.READY)
             self._price_server_read_loop()
         except Exception as e:
-            log.warning(f"connection attempt failed due to: {traceback.format_exc()}")
+            log.warning(f"connection attempt failed due to: {e}")
 
     def _prepare_new_session(self):
         self._compressor = MessageCompressor(self._opened_socket)
@@ -176,7 +175,7 @@ class PuffinProvider(PriceProvider):
                 self._handle_received_message(message)
         except Exception as e:
             self._publish_provider_status(
-                ProviderStatus.DOWN, f"connection error due to: {traceback.format_exc()}"
+                ProviderStatus.DOWN, f"connection error due to: {e}"
             )
             self._notify_all_subjects_as_stale(
                 f"price provider {self._provider_name} is down"
@@ -249,7 +248,7 @@ class PuffinProvider(PriceProvider):
             cipher = PKCS1_v1_5.new(key)
             return b64encode(cipher.encrypt(password.encode("utf-8")))
         except Exception as e:
-            log.error(traceback.format_exc())
+            log.error(e)
 
     @staticmethod
     def _verify_version(server_version):

--- a/tests/pixie/utils_test/test_varint.py
+++ b/tests/pixie/utils_test/test_varint.py
@@ -145,7 +145,16 @@ class TestReadFromSocket(unittest.TestCase):
 
     def test_reads_from_socket_until_requested_length_fulfilled(self):
         mock_socket = mock.Mock()
-        values = [b"ult", b"res"]
+        values = [b"res", b"ult"]
+        values.reverse()
+        mock_socket.recv = lambda _: values.pop()
+
+        self.assertEqual(b"result", read_bytes(mock_socket, 6))
+
+    def test_only_reads_from_socket_requested_length(self):
+        mock_socket = mock.Mock()
+        values = [b"res", b"ult", b"extra"]
+        values.reverse()
         mock_socket.recv = lambda _: values.pop()
 
         self.assertEqual(b"result", read_bytes(mock_socket, 6))

--- a/tests/pixie/utils_test/test_varint.py
+++ b/tests/pixie/utils_test/test_varint.py
@@ -138,8 +138,14 @@ class TestReadFromSocket(unittest.TestCase):
     def _mocked_socket_bytes(self, int_value):
         mock_socket = mock.Mock()
         value = [
-            int.to_bytes(i, byteorder="little", length=1)
-            for i in encode_varint(int_value)
+            int.to_bytes(i, byteorder="little", length=1) for i in encode_varint(int_value)
         ]
         mock_socket.recv = lambda x: value.pop(x - 1)
         return mock_socket
+
+    def test_reads_from_socket_until_requested_length_fulfilled(self):
+        mock_socket = mock.Mock()
+        values = [b"ult", b"res"]
+        mock_socket.recv = lambda _: values.pop()
+
+        self.assertEqual(b"result", read_bytes(mock_socket, 6))


### PR DESCRIPTION
The API was disconnecting from BidFX services upon submitting a large number of subscriptions. This was caused because the price updates received were larger than a single socket read. Fixed by repeating socket reads until the entire price map is received.